### PR TITLE
Solargraph の設定ファイルを追加するにあたって .gitignore にそのファイルを追加した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ yarn-error.log
 .byebug_history
 
 /public/system
+
+.solargraph.yml


### PR DESCRIPTION
`solargraph.yml` は次のように書く。

```yaml
reporters:
  - require_not_found
exclude:
  - vendor/**/*
  - '.bundle/**/*'
```